### PR TITLE
Multimoneda en percepciones (rama journals)

### DIFF
--- a/l10n_ar_perceptions_basic/__openerp__.py
+++ b/l10n_ar_perceptions_basic/__openerp__.py
@@ -20,7 +20,7 @@
 ##############################################################################
 {
     "name": "Perceptions for ARGENTINA (Percepciones) - Basic Module",
-    "version": "1.0",
+    "version": "1.2",
     "depends": ["base", "account" , "account_accountant", "sale" ,"purchase", "l10n_ar_point_of_sale"],
     "author": "E-MIPS,Odoo Community Association (OCA)",
     "website": "http://e-mips.com.ar",

--- a/l10n_ar_perceptions_basic/account_invoice_view.xml
+++ b/l10n_ar_perceptions_basic/account_invoice_view.xml
@@ -64,8 +64,10 @@
               <tree string="Perception Lines">
                 <field name="date" />
                 <field name="perception_id" string="Perception Type"/>
-                <field name="base" />
-                <field name="amount" />
+                <field name="base_currency" />
+                <field name="tax_currency" />
+                <field name="currency_id" invisible="1"/>
+                <field name="base" invisible="1"/>
                 <field name="state_id" />
               </tree>
               <form string="Perception Lines" version="7.0">
@@ -80,8 +82,10 @@
                           <label string="Keep date empty if the date is the same as the invoice." class="oe_grey"/>
                       </group>
                       <group string="Amounts" name="amount">
-                          <field name="base" />
-                          <field name="amount" />
+                          <field name="base" invisible="1" />
+                          <field name="amount" invisible="1" />
+                          <field name="base_currency" />
+                          <field name="tax_currency" />
                           <field name="account_id" invisible="1" />
                           <field name="base_code_id" invisible="1" />
                           <field name="tax_code_id" invisible="1" />

--- a/l10n_ar_perceptions_basic/account_invoice_view.xml
+++ b/l10n_ar_perceptions_basic/account_invoice_view.xml
@@ -15,8 +15,11 @@
               <tree string="Perception Lines">
                 <field name="date" />
                 <field name="perception_id" string="Perception Type"/>
-                <field name="base" />
-                <field name="amount" />
+                <field name="base_currency" />
+                <field name="tax_currency" />
+                <field name="currency_id" invisible="1"/>
+                <field name="base" invisible="1"/>
+                <field name="amount" invisible="1"/>
                 <field name="state_id" />
               </tree>
               <form string="Perception Lines" version="7.0">
@@ -31,8 +34,11 @@
                           <label string="Keep date empty if the date is the same as the invoice." class="oe_grey"/>
                       </group>
                       <group string="Amounts" name="amount">
-                          <field name="base" />
-                          <field name="amount" />
+                          <field name="base" invisible="1" />
+                          <field name="amount" invisible="1" />
+                          <field name="base_currency" />
+                          <field name="tax_currency" />
+                          <field name="currency_id" invisible="1"/>
                           <field name="account_id" invisible="1" />
                           <field name="base_code_id" invisible="1" />
                           <field name="tax_code_id" invisible="1" />

--- a/l10n_ar_perceptions_basic/i18n/l10n_ar_perceptions_basic.po
+++ b/l10n_ar_perceptions_basic/i18n/l10n_ar_perceptions_basic.po
@@ -1,323 +1,310 @@
 # Translation of OpenERP Server.
 # This file contains the translation of the following modules:
-# 	* l10n_ar_perceptions_basic
-# Sebastian Kennedy <skennedy@e-mips.com.ar>, 2016.
+#	* l10n_ar_perceptions_basic
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 7.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-14 18:43+0000\n"
-"PO-Revision-Date: 2016-12-14 15:47-0300\n"
-"Last-Translator: Sebastian Kennedy <skennedy@e-mips.com.ar>\n"
-"Language-Team: Spanish; Castilian <>\n"
-"Language: es_AR\n"
+"POT-Creation-Date: 2016-12-14 18:41+0000\n"
+"PO-Revision-Date: 2016-12-14 18:41+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Gtranslator 2.91.7\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
 
 #. module: l10n_ar_perceptions_basic
 #: view:account.invoice:0
 msgid "Information"
-msgstr "Información"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: field:perception.tax.line,base_currency:0
 msgid "Base Amount"
-msgstr "Monto Base"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: selection:perception.perception,jurisdiccion:0
 msgid "Provincial"
-msgstr "Provincial"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: view:perception.tax.line:0
 msgid "Base Total"
-msgstr "Total Base"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: view:account.invoice:0
 msgid "Amounts"
-msgstr "Montos"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: field:perception.perception,tax_id:0
 msgid "Tax"
-msgstr "Impuesto"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: field:perception.tax.line,tax_code_id:0
 msgid "Tax Code"
-msgstr "Código de impuesto"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: help:perception.tax.line,tax_code_id:0
 msgid "The tax basis of the tax declaration."
-msgstr "Base imponible de la declaración de impuestos"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: selection:perception.perception,jurisdiccion:0
 msgid "Nacional"
-msgstr "Nacional"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
-#: field:perception.perception,state_id:0 field:perception.tax.line,state_id:0
+#: field:perception.perception,state_id:0
+#: field:perception.tax.line,state_id:0
 msgid "State/Province"
-msgstr "Estado/Provincia"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: view:perception.tax.line:0
 msgid "Group By..."
-msgstr "Agrupar por..."
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: selection:perception.perception,type:0
 msgid "Other"
-msgstr "Otro"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: field:perception.perception,type:0
 msgid "Type"
-msgstr "Tipo"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: view:account.invoice:0
 msgid "Invoice Lines"
-msgstr "Líneas de la factura"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: view:perception.tax.line:0
 msgid "Province"
-msgstr "Provincia"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: field:perception.tax.line,base_code_id:0
 msgid "Base Code"
-msgstr "Código de la base"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: selection:perception.perception,jurisdiccion:0
 msgid "Municipal"
-msgstr "Municipal"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: field:perception.tax.line,vat:0
 msgid "CIF/NIF"
-msgstr "CUIT"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: field:perception.tax.line,company_id:0
 msgid "Company"
-msgstr "Compañía"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: model:ir.actions.act_window,name:l10n_ar_perceptions_basic.action_perception_tax_tree
 msgid "Perception Tax Applied"
-msgstr "Percepciones Aplicadas"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: model:ir.actions.act_window,name:l10n_ar_perceptions_basic.action_perception_tax_supported_tree
 msgid "Perception Tax Supported"
-msgstr "Percepciones Soportadas"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: selection:perception.perception,type:0
 msgid "Profit"
-msgstr "Ganancias"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: view:account.invoice:0
 msgid "Supported Perceptions"
-msgstr "Percepciones soportadas"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: selection:perception.perception,type:0
 msgid "VAT"
-msgstr "IVA"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: view:perception.tax.line:0
 msgid "Perception Tax Lines"
-msgstr "Líneas de Percepción"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
-#: view:perception.tax.line:0 field:perception.tax.line,date:0
+#: view:perception.tax.line:0
+#: field:perception.tax.line,date:0
 msgid "Date"
-msgstr "Fecha"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: help:perception.perception,tax_id:0
 msgid "Tax configuration for this perception"
-msgstr "Configuración de impuestos para la percepción"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: field:perception.tax.line,base:0
 msgid "Base (Company Cur)"
-msgstr "Base (Moneda Compañía)"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: view:account.invoice:0
 #: model:ir.ui.menu,name:l10n_ar_perceptions_basic.perception_perception_menu
 #: view:perception.perception:0
 msgid "Perceptions"
-msgstr "Percepciones"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: view:perception.tax.line:0
 msgid "Applied"
-msgstr "Aplicadas"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: selection:perception.perception,type:0
 msgid "Gross Income"
-msgstr "Ingresos Brutos"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: model:ir.ui.menu,name:l10n_ar_perceptions_basic.perception_tax_line_supported_menu
 #: view:perception.tax.line:0
 msgid "Perception Supported"
-msgstr "Percepciones Soportadas"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: view:account.invoice:0
 msgid "Keep date empty if the date is the same as the invoice."
-msgstr "Dejar vacío si la fecha es la misma que la de la factura."
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: field:perception.perception,type_tax_use:0
 msgid "Tax Application"
-msgstr "Aplicación de impuesto"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: field:perception.tax.line,tax_currency:0
 msgid "Tax Amount"
-msgstr "Monto Impuesto"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: field:perception.tax.line,account_id:0
 msgid "Tax Account"
-msgstr "Cuenta de impuestos"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: field:account.invoice,perception_ids:0
 #: model:ir.actions.act_window,name:l10n_ar_perceptions_basic.action_perception_perception_tree
-#: field:perception.perception,name:0 field:perception.tax.line,name:0
+#: field:perception.perception,name:0
+#: field:perception.tax.line,name:0
 msgid "Perception"
-msgstr "Percepción"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: view:account.invoice:0
 msgid "Perception Type"
-msgstr "Tipo de percepción"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: help:perception.tax.line,base_code_id:0
 msgid "The account basis of the tax declaration."
-msgstr "Cuenta base de la declaración de impuestos"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: model:ir.ui.menu,name:l10n_ar_perceptions_basic.perception_tax_line_applied_menu
 #: view:perception.tax.line:0
 msgid "Perception Applied"
-msgstr "Percepciones Aplicadas"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: model:ir.model,name:l10n_ar_perceptions_basic.model_account_invoice_tax
 #: field:perception.tax.line,ait_id:0
 msgid "Invoice Tax"
-msgstr "Impuestos sobre Factura"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: help:perception.tax.line,perception_id:0
-msgid ""
-"Perception configuration used '                                       'for "
-"this perception tax, where all the configuration resides. Accounts, Tax "
-"Codes, etc."
+msgid "Perception configuration used '                                       'for this perception tax, where all the configuration resides. Accounts, Tax Codes, etc."
 msgstr ""
-"Datos para la configuración de la percepción, cuentas, códigos de impuestos, "
-"etc."
 
 #. module: l10n_ar_perceptions_basic
 #: model:ir.model,name:l10n_ar_perceptions_basic.model_perception_tax_line
 #: view:perception.tax.line:0
 msgid "Perception Tax Line"
-msgstr "Línea de impuesto de la percepción"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: field:perception.perception,jurisdiccion:0
 msgid "Jurisdiccion"
-msgstr "Jurisdicción"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: model:ir.actions.act_window,help:l10n_ar_perceptions_basic.action_perception_tax_supported_tree
 #: model:ir.actions.act_window,help:l10n_ar_perceptions_basic.action_perception_tax_tree
-msgid ""
-"<p class=\"oe_view_nocontent_create\">\n"
+msgid "<p class=\"oe_view_nocontent_create\">\n"
 "            Click to create a perception.\n"
 "          </p>\n"
 "        "
 msgstr ""
-"<p class=\"oe_view_nocontent_create\">\n"
-"            Clickear para crear una Percepción.\n"
-"          </p>\n"
-"        "
 
 #. module: l10n_ar_perceptions_basic
 #: view:account.invoice:0
 msgid "Perception Lines"
-msgstr "Líneas de percepciones"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: field:perception.tax.line,amount:0
 msgid "Amount (Company Cur)"
-msgstr "Monto (Moneda Compañía)"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: view:perception.tax.line:0
 msgid "Supported"
-msgstr "Soportada"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: model:ir.actions.act_window,help:l10n_ar_perceptions_basic.action_perception_perception_tree
-msgid ""
-"Here you can define Perceptions and their configuration to be used in "
-"Customer Invoices or Supplier Invoices"
+msgid "Here you can define Perceptions and their configuration to be used in Customer Invoices or Supplier Invoices"
 msgstr ""
-"Desde aquí podrá definir las percepciones y su configuración, que serán "
-"utilizadas en las facturas de clientes y proveedores."
 
 #. module: l10n_ar_perceptions_basic
 #: field:perception.tax.line,currency_id:0
 msgid "Currency"
-msgstr "Moneda"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: view:account.invoice:0
 #: model:ir.model,name:l10n_ar_perceptions_basic.model_account_invoice
 #: field:perception.tax.line,invoice_id:0
 msgid "Invoice"
-msgstr "Factura"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: model:ir.model,name:l10n_ar_perceptions_basic.model_perception_perception
 #: field:perception.tax.line,perception_id:0
 msgid "Perception Configuration"
-msgstr "Configuración de la percepción"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: field:perception.tax.line,partner_id:0
 msgid "Partner"
-msgstr "Empresa"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: view:account.invoice:0
 msgid "Applied Perceptions"
-msgstr "Percepciones Aplicadas"
+msgstr ""
 
 #. module: l10n_ar_perceptions_basic
 #: view:perception.tax.line:0
 msgid "Amount Total"
-msgstr "Total"
+msgstr ""
+

--- a/l10n_ar_perceptions_basic/migrations/7.0.1.1/post-populate-columns.py
+++ b/l10n_ar_perceptions_basic/migrations/7.0.1.1/post-populate-columns.py
@@ -1,0 +1,38 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (c) 2016 E-MIPS (http://www.e-mips.com.ar)
+#    Copyright (c) 2016 Eynes (http://www.eynes.com.ar)
+#    Copyright (c) 2016 Aconcagua Team (http://www.aconcagua.com.ar)
+#    All Rights Reserved. See AUTHORS for details.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+# Le agregamos feature de multimoneda a este modulo, por lo tanto vamos a usar
+# los campos base_code_amount y tax_code_amount que no estaban siendo usados y los
+# debemos llenar con lo mismo que el base y amount respectivamente
+__name__ = u"Popula las columnas tax_code_amount y base_code_amount por multimoneda"
+
+
+def populate_base_tax_code_amount_columns(cr):
+    cr.execute("""
+        UPDATE perception_tax_line SET tax_amount=amount, base_amount=base
+        """)
+
+def migrate(cr, version):
+    if not version:
+        return
+    populate_base_tax_code_amount_columns(cr)

--- a/l10n_ar_perceptions_basic/migrations/7.0.1.2/pre-alter-columns.py
+++ b/l10n_ar_perceptions_basic/migrations/7.0.1.2/pre-alter-columns.py
@@ -1,0 +1,47 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (c) 2016 E-MIPS (http://www.e-mips.com.ar)
+#    Copyright (c) 2016 Eynes (http://www.eynes.com.ar)
+#    Copyright (c) 2016 Aconcagua Team (http://www.aconcagua.com.ar)
+#    All Rights Reserved. See AUTHORS for details.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+__name__ = u"Cambia nombre de las columnas tax_amount y base_amount para multimoneda"
+
+from psycopg2 import ProgrammingError
+import logging
+
+logger = logging.getLogger(__name__)
+
+def migrate(cr, version):
+    if not version:
+        return
+    import ipdb; ipdb.set_trace()
+    try:
+        cr.execute("""
+            ALTER TABLE perception_tax_line RENAME COLUMN tax_amount TO tax_currency
+            """)
+
+        cr.execute("""
+            ALTER TABLE perception_tax_line RENAME COLUMN base_amount TO base_currency
+            """)
+    except ProgrammingError:
+        logger.info("Migration already applied.")
+        cr.rollback()
+
+

--- a/l10n_ar_perceptions_basic/perception_view.xml
+++ b/l10n_ar_perceptions_basic/perception_view.xml
@@ -78,7 +78,10 @@
           <field name="vat"/>
           <field name="amount" sum="Amount Total"/>
           <field name="base" sum="Base Total"/>
-          <field name="state_id"/>
+           <field name="currency_id" groups="base.group_multi_currency"/>
+          <field name="tax_currency" groups="base.group_multi_currency"/>
+          <field name="base_currency" groups="base.group_multi_currency"/>
+           <field name="state_id"/>
           <field name="company_id" groups="base.group_multi_company"/>
       </tree>
     </field>
@@ -102,8 +105,11 @@
               </group>
               <group>
                 <group>
-                  <field name="amount" sum="Amount Total"/>
-                  <field name="base" sum="Base Total"/>
+                   <field name="currency_id"/>
+                  <field name="tax_currency"/>
+                  <field name="base_currency"/>
+                  <field name="amount" invisible="1"/>
+                  <field name="base" invisible="1"/>
                 </group>
                 <group>
                   <field name="state_id"/>


### PR DESCRIPTION
Se modifica el código del módulo l10n_ar_perceptions_basic para poder realizar facturas en moneda extranjera. Por lo cual, ahora se tiene tres nuevas columnas. Dos para montos en moneda (local o extranjera) y una tercera para la moneda extranjera.
Se realizan los cambios de forma que los campos que se utilizan actualmente de **monto y base** no se cambien y por ende, reportes, archivos generados, etc de otros módulos pueden seguir funcionando sin problemas.