### PR TITLE
[RM] Se elimina funcion que modificaba el tax_amount

### DIFF
--- a/l10n_ar_wsfe/invoice.py
+++ b/l10n_ar_wsfe/invoice.py
@@ -366,30 +366,3 @@ class account_invoice(osv.osv):
         return True
 
 account_invoice()
-
-
-class account_invoice_tax(osv.osv):
-    _name = "account.invoice.tax"
-    _inherit = "account.invoice.tax"
-
-
-    def hook_compute_invoice_taxes(self, cr, uid, invoice_id, tax_grouped, context=None):
-        tax_obj = self.pool.get('account.tax')
-        cur_obj = self.pool.get('res.currency')
-        inv = self.pool.get('account.invoice').browse(cr, uid, invoice_id, context=context)
-        cur = inv.currency_id
-
-        for t in tax_grouped.values():
-            # Para solucionar el problema del redondeo con AFIP
-            ta = tax_obj.browse(cr, uid, t['tax_id'], context=context)
-            t['amount'] = t['base']*ta.amount
-            t['tax_amount'] = t['base_amount']*ta.amount
-
-            t['base'] = cur_obj.round(cr, uid, cur, t['base'])
-            t['amount'] = cur_obj.round(cr, uid, cur, t['amount'])
-            t['base_amount'] = cur_obj.round(cr, uid, cur, t['base_amount'])
-            t['tax_amount'] = cur_obj.round(cr, uid, cur, t['tax_amount'])
-
-        return super(account_invoice_tax, self).hook_compute_invoice_taxes(cr, uid, invoice_id, tax_grouped, context)
-
-account_invoice_tax()


### PR DESCRIPTION
1. Era para resolver problemas de redondeo para la afip pero buscando en
el codigo no veo que se use tax_amount para enviar a afip

Esto generaba esta clase de lineas contables:
![image](https://user-images.githubusercontent.com/9728965/29626233-751191cc-8804-11e7-8b99-300eba1a048d.png)
