### PR TITLE
Little Fix & Field as Invisible

### DIFF
--- a/l10n_ar_account_check/account_check_view.xml
+++ b/l10n_ar_account_check/account_check_view.xml
@@ -119,7 +119,7 @@
                             <group>
                                 <field name="origin"/>
                                 <field name="payment_move_id" readonly="1"/>
-                                <field name="clearance_move_id" readonly="1"/>
+                                <field name="clearance_move_id" attrs="{'readonly': True, 'invisible': [('type', '=', 'common')]}"/>
                                 <field name="accredited" invisible="1"/>
                             </group>
                          </group>

--- a/l10n_ar_account_create_check/checkbook.py
+++ b/l10n_ar_account_create_check/checkbook.py
@@ -43,6 +43,8 @@ class account_checkbook(models.Model):
 
     @api.depends("check_ids", "check_ids.state", "state")
     def calc_anulled_checks(self):
+        if type(self.id) !=  int:
+            return False
         query = """
         SELECT id
         FROM account_checkbook_check
@@ -58,6 +60,7 @@ class account_checkbook(models.Model):
                 check_ids = []
 
             checkbook.annulled_checks = [(6, False, check_ids)]
+        return True
 
     name = fields.Char('Checkbook Number', size=32, required=True)
     bank_id = fields.Many2one('res.bank', 'Bank', required=True)


### PR DESCRIPTION
Se esconde el campo de "Asiento contable de Pago" en los cheques comunes, ya que generan un solo asiento cuando se generan.
Se arregla un bug en la creación de chequeras, ya que quería traer los cheques anulados y todavía no había create Id en base de datos.