### PR TITLE
[ADD] Hide supplier_invoice_number field from supplier invoice's view

### DIFF
--- a/l10n_ar_point_of_sale/account_invoice_view.xml
+++ b/l10n_ar_point_of_sale/account_invoice_view.xml
@@ -116,6 +116,9 @@
                     <field name="fiscal_position" position="attributes">
                         <attribute name="required">1</attribute>
                     </field>
+                    <field name="supplier_invoice_number" position="attributes">
+                        <attribute name="invisible">1</attribute>
+                    </field>
                    <field name="amount_untaxed" position="replace">
                        <field name="amount_taxed" widget="monetary" options="{'currency_field': 'currency_id'}"/>
                        <field name="amount_no_taxed" widget="monetary" options="{'currency_field': 'currency_id'}"/>


### PR DESCRIPTION
Make that field invisible by inheritance. It's annoying for some customers.