### PR TITLE
[11.0][l10n_ar_bank_statement] Do not edit Statement Lines on 'Add Lines' wizard.

### DIFF
--- a/l10n_ar_bank_statement/__manifest__.py
+++ b/l10n_ar_bank_statement/__manifest__.py
@@ -20,7 +20,7 @@
 
 {
     "name": "Bank Statements for Argentina",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.0.1",
     "author": "Eynes",
     "website": "http://www.eynes.com.ar",
     "category": "Accounting",
@@ -33,6 +33,7 @@
     "data": [
         'data/ir_sequence_data.xml',
         'wizard/pos_box_view.xml',
+        'views/bank_statement_line_view.xml',
         'wizard/account_add_bank_statement_view.xml',
         'wizard/account_import_bank_statement_line_view.xml',
         'views/pos_box_concept_view.xml',

--- a/l10n_ar_bank_statement/views/bank_statement_line_view.xml
+++ b/l10n_ar_bank_statement/views/bank_statement_line_view.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <!-- a low priority account.bank.statement.line readonly form view to be used in the add lines wizard -->
+
+    <record id="view_account_bank_statement_line_form_readonly" model="ir.ui.view">
+        <field name="name">account.bank.statement.line.form.readonly</field>
+        <field name="model">account.bank.statement.line</field>
+        <field name="type">form</field>
+        <field name="priority" eval="10000"/>
+        <field name="arch" type="xml">
+        <form string="Statement Line">
+            <group col="4" colspan="2">
+                <field name="statement_id" readonly="1"/>
+                <field name="date" readonly="1"/>
+                <field name="name" readonly="1"/>
+                <field name="ref" readonly="1"/>
+                <field name="partner_id" readonly="1"/>
+                <field name="amount" readonly="1"/>
+                <field name="journal_currency_id" readonly="1" invisible="1"/>
+                <field name="sequence" readonly="1"/>
+                <field name="note" colspan="4" readonly="1"/>
+            </group>
+        </form>
+        </field>
+    </record>
+
+</odoo>

--- a/l10n_ar_bank_statement/wizard/account_add_bank_statement_view.xml
+++ b/l10n_ar_bank_statement/wizard/account_add_bank_statement_view.xml
@@ -12,6 +12,7 @@
                 <field name="statement_id" invisible="1"/>
                 <field name="journal_id" invisible="1"/>
                 <field name="statement_line_ids" colspan="4" nolabel="1" options="{'no_create': true}"
+                    context="{'form_view_ref': 'l10n_ar_bank_statement.view_account_bank_statement_line_form_readonly'}"
                     domain="[('state', '=', 'open'), ('statement_id', '=', False), ('journal_id','=', journal_id)]">
                     <search>
                         <field name="date"/>


### PR DESCRIPTION
Adds a custom `account.bank.statement.line` readonly form view to avoid these lines to be edited on the 'Add Lines' wizard.