### PR TITLE
[FIX] Show default_pos after tz instead of barcode. It's done so to a…

### DIFF
--- a/l10n_ar_point_of_sale/views/res_users_view.xml
+++ b/l10n_ar_point_of_sale/views/res_users_view.xml
@@ -5,7 +5,7 @@
         <field name="model">res.users</field>
         <field name="inherit_id" ref="base.view_users_form" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='barcode']" position="after">
+            <xpath expr="//field[@name='tz']" position="after">
                 <field name="default_pos"/>
             </xpath>
         </field>


### PR DESCRIPTION
…void inheriting from 'point_of_sale' addon, where res.users.barcode field is defined